### PR TITLE
Fix test failing due to missing task block

### DIFF
--- a/src/Entity/Currency/CurrencyForm.php
+++ b/src/Entity/Currency/CurrencyForm.php
@@ -182,8 +182,8 @@ class CurrencyForm extends EntityForm {
     elseif ($currency->isNew()) {
       $loaded_currency = $this->currencyStorage->load($currency_code);
       if ($loaded_currency) {
-        $form_state->setError($element, $this->t('The currency code is already in use by !link.', array(
-          '!link' => $this->linkGenerator->generate($loaded_currency->label(), $loaded_currency->urlInfo('edit-form')),
+        $form_state->setError($element, $this->t('The currency code is already in use by @link.', array(
+          '@link' => $this->linkGenerator->generate($loaded_currency->label(), $loaded_currency->urlInfo('edit-form')),
         )));
       }
     }
@@ -204,8 +204,8 @@ class CurrencyForm extends EntityForm {
       ));
       if ($loaded_currencies) {
         $loaded_currency = reset($loaded_currencies);
-        $form_state->setError($element, $this->t('The currency number is already in use by !link.', array(
-          '!link' => $this->linkGenerator->generate($loaded_currency->label(), $loaded_currency->urlInfo('edit-form')),
+        $form_state->setError($element, $this->t('The currency number is already in use by @link.', array(
+          '@link' => $this->linkGenerator->generate($loaded_currency->label(), $loaded_currency->urlInfo('edit-form')),
         )));
       }
     }

--- a/src/Tests/Controller/CurrencyLocaleWebTest.php
+++ b/src/Tests/Controller/CurrencyLocaleWebTest.php
@@ -16,13 +16,15 @@ use Drupal\simpletest\WebTestBase;
  */
 class CurrencyLocaleWebTest extends WebTestBase {
 
-  public static $modules = array('currency');
+  public static $modules = array('currency', 'block');
 
   /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
+    $this->drupalPlaceBlock('local_tasks_block');
+
     /** @var \Drupal\currency\ConfigImporterInterface $config_importer */
     $config_importer = \Drupal::service('currency.config_importer');
     $config_importer->importCurrencyLocale('nl_NL');


### PR DESCRIPTION
Is needed because this assert fails and is related to a tab.

$currency_locale_overview_path = 'admin/config/regional/currency-formatting/locale';
$this->assertLinkByHref($currency_locale_overview_path);
