### PR TITLE
Remove language_code in Unit test

### DIFF
--- a/tests/src/Unit/Entity/Currency/CurrencyAccessControlHandlerTest.php
+++ b/tests/src/Unit/Entity/Currency/CurrencyAccessControlHandlerTest.php
@@ -115,9 +115,7 @@ class CurrencyAccessControlHandlerTest extends UnitTestCase {
     $method = new \ReflectionMethod($this->sut, 'checkAccess');
     $method->setAccessible(TRUE);
 
-    $language_code = $this->randomMachineName();
-
-    $this->assertSame($expected_value, $method->invoke($this->sut, $currency, $operation, $language_code, $account)->isAllowed());
+    $this->assertSame($expected_value, $method->invoke($this->sut, $currency, $operation, $account)->isAllowed());
   }
 
   /**


### PR DESCRIPTION
In the build.log of d8status we have the following error.
 Drupal\Tests\currency\Unit\Entity\Currency\CurrencyAccessControlHandlerTest::testCheckAccess with data set #9 (false, 'delete', false, 'currency.currency.delete')
Argument 3 passed to Drupal\currency\Entity\Currency\CurrencyAccessControlHandler::checkAccess() must implement interface Drupal\Core\Session\AccountInterface, string given

So I checked the unit test and it seems is using a $language_code that is no more necessary in CurrencyAccessControlHandler::checkAccess(). So removing it might fix the test.
